### PR TITLE
Fix PHP syntax error in Packages.php, line 35.

### DIFF
--- a/lib/Postmaster/Package.php
+++ b/lib/Postmaster/Package.php
@@ -32,7 +32,7 @@ class Postmaster_Package extends Postmaster_ApiResource
   {
     $requestor = new Postmaster_ApiRequestor();
     $params = json_encode($params);
-    $headers = ['Content-Type: application/json'];
+    $headers = array("Content-Type: application/json'");
     $response = $requestor->request('post', self::$urlBase.'/fit', $params, $headers);
     return $response;
   }


### PR DESCRIPTION
Out of the box the postmaster PHP library doesn't work.

Parse error: parse error in postmaster-php/lib/Postmaster/Package.php on line 35

I am running on OSX:

PHP 5.3.15 with Suhosin-Patch (cli) (built: Dec  9 2012 19:32:02)
Copyright (c) 1997-2012 The PHP Group
Zend Engine v2.3.0, Copyright (c) 1998-2012 Zend Technologies

It looks like $headers is trying to be an array, but the syntax is incorrect.
