### PR TITLE
Monitor external package now returns response

### DIFF
--- a/lib/Postmaster/Tracking.php
+++ b/lib/Postmaster/Tracking.php
@@ -24,7 +24,7 @@ class Postmaster_Tracking extends Postmaster_ApiResource
     Postmaster_ApiResource::_validateParams($params);
     $requestor = new Postmaster_ApiRequestor();
     $response = $requestor->request('post', self::$urlBase, $params);
-    return True;
+    return $response;
   }
 }
 


### PR DESCRIPTION
monitor_external() now returns the response from the remote, rather than simply TRUE. This response contains helpful information, including the current status of the requested package and an estimated delivery date.
